### PR TITLE
boot vm on boot on mac

### DIFF
--- a/macosx/installvagrantboot.sh
+++ b/macosx/installvagrantboot.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+
+#set up variables
+LOGNAME=$(logname)
+PLISTPATH=/Library/LaunchDaemons/
+PLISTNAME=com.vagrantboot.test
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/"
+SCRIPTNAME=vagrantboot.sh
+STDE=stde.txt
+STDO=stdo.txt
+VMNAME=community
+PLISTCONTENT="
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+	<dict>
+		<key>Label</key>
+		<string>${PLISTNAME}.plist</string>
+		<key>ProgramArguments</key>
+		<array>
+			<string>${SCRIPTPATH}${SCRIPTNAME}</string>
+		</array>
+		<key>WorkingDirectory</key>
+    	<string>/Users/${LOGNAME}</string>
+		<key>StandardOutPath</key>
+	    <string>$SCRIPTPATH${STDO}</string>
+	    <key>StandardErrorPath</key>
+	    <string>$SCRIPTPATH${STDE}</string>
+		<key>RunAtLoad</key>
+		<true/>
+	</dict>
+</plist>"
+
+SCRIPTCONTENT="
+export PATH=$PATH:/usr/local/bin\n
+sudo -u ${LOGNAME} vboxmanage startvm $VMNAME --type headless
+"
+
+# create stdout for the script
+touch $SCRIPTPATH$STDO
+> $SCRIPTPATH$STDO
+
+# create stderr for the script
+touch $SCRIPTPATH$STDE
+> $SCRIPTPATH$STDE
+
+# create the plist in the /Library/LaunchDaemons/ folder
+touch $PLISTPATH${PLISTNAME}.plist
+> $PLISTPATH${PLISTNAME}.plist
+echo $PLISTCONTENT >> $PLISTPATH${PLISTNAME}.plist 
+
+# create the main script file
+touch $SCRIPTPATH$SCRIPTNAME
+> $SCRIPTPATH$SCRIPTNAME
+echo $SCRIPTCONTENT >> $SCRIPTPATH$SCRIPTNAME
+
+chmod 777 $SCRIPTPATH$SCRIPTNAME
+


### PR DESCRIPTION
Add installvagrantboot.sh under macosx. This file will run the necessary configuration to make the mac system auto boot the vm machine on boot. 

Since it is my first time writing a formal script, it might look ugly. 

A few things to mention:
a). This file need to be run as root user. So if it is run manually, do 
`sudo sh installvagrantboot.sh`

b). I used 
`sudo -u ${LOGNAME} vboxmanage startvm $VMNAME --type headless`
instead of 
`sudo -u ${LOGNAME} vagrant reload $VMNAME`
because it seems that the "vagrant reload" command fail to target the vm by using its name, "community" in this case. Not sure if this matter.
### WARNING!!!: Since I use the vboxmanage interface instead of the vagrant interface, after the virtual machine is successfully turned on, the "vagrant global-status" will still see the machine as "poweroff". You can use command "vboxmanage list runningvms" to check the current running vm or just try to run the [App link](127.0.0.1:5984/apps/_design/bell/MyApp/index.html) on firefox to see if it work.

c). After running this script file, instead of literally restarting the mac system for testing, run the following command.
`sudo launchctl load /Library/LaunchDaemons/com.vagrantboot.test.plist`
If this fail, then run the following.
`sudo launchctl unload /Library/LaunchDaemons/com.vagrantboot.test.plist`
`sudo launchctl load /Library/LaunchDaemons/com.vagrantboot.test.plist`

d). This script will generate stdo.txt and stde.txt files on the same folder to receive general and error messages correspondingly. 
#### So if things go wrong, look inside these two files to get the error message.
