### PR TITLE
remove username dependence and need for drag_me_into_startup_folder.bat

### DIFF
--- a/windows/start_vagrant_on_boot.bat
+++ b/windows/start_vagrant_on_boot.bat
@@ -1,4 +1,5 @@
 ECHO OFF
+start cmd /c copy "C:\Users\%USERNAME%\ole--vagrant-community\windows\start_vagrant_on_boot.bat" "C:\Users\%USERNAME%\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup"
 cd /d %~dp0
 for /f "tokens=2* delims= " %%F IN ('vagrant status ^| find /I "default"') DO (SET "STATE=%%F%%G")
 

--- a/windows/start_vagrant_on_boot.bat
+++ b/windows/start_vagrant_on_boot.bat
@@ -1,9 +1,6 @@
 ECHO OFF
 start cmd /c copy "C:\Users\%USERNAME%\ole--vagrant-community\windows\start_vagrant_on_boot.bat" "C:\Users\%USERNAME%\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup"
-<<<<<<< HEAD
 cd "C:\Users\%USERNAME%\ole--vagrant-community\windows"
-=======
->>>>>>> upstream/master
 cd /d %~dp0
 for /f "tokens=2* delims= " %%F IN ('vagrant status ^| find /I "default"') DO (SET "STATE=%%F%%G")
 

--- a/windows/start_vagrant_on_boot.bat
+++ b/windows/start_vagrant_on_boot.bat
@@ -1,5 +1,6 @@
 ECHO OFF
 start cmd /c copy "C:\Users\%USERNAME%\ole--vagrant-community\windows\start_vagrant_on_boot.bat" "C:\Users\%USERNAME%\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup"
+cd "C:\Users\%USERNAME%\ole--vagrant-community\windows"
 cd /d %~dp0
 for /f "tokens=2* delims= " %%F IN ('vagrant status ^| find /I "default"') DO (SET "STATE=%%F%%G")
 


### PR DESCRIPTION
So, this should remove the need for the extra script and fix the username dependence. Essentially, after this script is run once, it copies itself into the startup folder, sets the directory to ole--vagrant-community/windows, and boots vagrant. After, every time on boot, the script in the startup folder should run, doing the same.
